### PR TITLE
remove-word-break

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -1,4 +1,3 @@
 @import 'settings';
 @import 'foundation-emails';
-
 @import 'template/template';

--- a/src/assets/scss/template/_template.scss
+++ b/src/assets/scss/template/_template.scss
@@ -4,8 +4,16 @@
 
 // Load our custom font.
 @import url('https://fonts.googleapis.com/css2?family=Nunito:wght@300;400;600&display=swap');
-p, h1, h2, h3, h4, ol, li, ul, a {
+
+p, h1, h2, h3, h4, ol, li, ul, a, tr, td, th {
   font-family: 'Nunito', sans-serif !important;
+  // Here we force the clients not allow word breaking with hyphens that normalize creates.
+  overflow-wrap: normal !important;
+  word-break: normal !important;
+  hyphens: none !important;
+  word-wrap: none !important;
+  -webkit-hyphens: none !important;
+  -moz-hyphens: none !important;
 }
 
 @mixin large-title {


### PR DESCRIPTION
* [x] Reset word break settings that Normalize creates. Warning, his means long words can and will break the layout of the email and remove the responsiveness of it. But at least there won't be hyphens and cut words.

⚠️ Use &shy; or <wbr> to control your word breaking now instead, if you have super long words, to ensure the responsiveness works.